### PR TITLE
[1.21.8] [FIX] Fix issues link in fabric.mod.json

### DIFF
--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
   "contact": {
     "homepage": "https://curseforge.com/minecraft/mc-mods/collective",
     "sources": "https://github.com/Serilum/Collective",
-    "issues": "https://github.com/Serilum/.issue-tracker/labels/Library: Collective"
+    "issues": "https://github.com/Serilum/.issue-tracker/labels/%22Library%3A%20Collective%22"
   },
 
   "license": "All Rights Reserved",


### PR DESCRIPTION
### Description
Currently the link crashes Minecraft if the Legacy 4J mod is installed and crashes with an invalid link exception. This issue is described in [issue #3100](https://github.com/Serilum/.issue-tracker/issues/3100) in the main issues repo. This fixes the exception when hovering over the mod in the mod menu.
> [!NOTE]
> This fixes the link on Fabric only.

### Crash Report
Minecraft crashed. The logs have been uploaded to [gnomebot.dev](gnomebot.dev): 
### [latest.log]
(<https://gnomebot.dev/paste/mclogs/JJ2ZsWe>) | [crash-2025-10-26_16.23.04-client.txt]
(<https://gnomebot.dev/paste/mclogs/RAKpx69>) | [PrismLauncher-0.log]
(<https://gnomebot.dev/paste/mclogs/XkLpzGQ>) | [crash_assistant_app.log]
(<https://gnomebot.dev/paste/mclogs/y40c4SR>) | [modlist.txt]
(<https://gnomebot.dev/paste/mclogs/E04eu6h>)
### Mod list changes after the latest successful launch: 
```ansi
[2;34mMod list was not modified.[0m
```

### Device Details
- OS: macOS Tahoe 26.0.1 (25A362)
- Java Installation: ~/Library/Application Support/PrismLauncher/java/java-runtime-delta/bin/java
- Launcher: Prism Launcher
- Minecraft Version: 1.21.8