### PR TITLE
Only hide HUD when debug overlay is visible

### DIFF
--- a/Common/src/main/java/com/natamus/collective/functions/GUIFunctions.java
+++ b/Common/src/main/java/com/natamus/collective/functions/GUIFunctions.java
@@ -4,6 +4,6 @@ import net.minecraft.client.Minecraft;
 
 public class GUIFunctions {
     public static boolean shouldHideGUI() {
-        return Minecraft.getInstance().gui.getDebugOverlay().showDebugScreen() || Minecraft.getInstance().options.hideGui;
+        return Minecraft.getInstance().debugEntries.isOverlayVisible() || Minecraft.getInstance().options.hideGui;
     }
 }


### PR DESCRIPTION
Previously, mods like GUI Clock do not render their HUDs when either chunk borders or hitboxes are shown, or when a debug entry is set to always display. This PR changes it to only hide HUD when the debug overlay is actually enabled.

This PR aims to fix https://github.com/Serilum/.issue-tracker/issues/3337, https://github.com/Serilum/.issue-tracker/issues/3421, https://github.com/Serilum/.issue-tracker/issues/3485, https://github.com/Serilum/.issue-tracker/issues/3514, https://github.com/Serilum/.issue-tracker/issues/3517, https://github.com/Serilum/.issue-tracker/issues/3584, https://github.com/Serilum/.issue-tracker/issues/3665 (and possibly more.)